### PR TITLE
Generate random MQTT client IDs to support multiple concurrent instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9
 
-RUN pip3 install paho-mqtt
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt
 COPY HHCIODriver.py /usr/local/bin/HHCIODriver.py
 COPY main.py /usr/local/bin/main.py
 

--- a/main.py
+++ b/main.py
@@ -7,10 +7,12 @@ import paho.mqtt.client as mqtt
 import sys
 import threading
 import time
+import hashlib
 
 mqtt_prefix = os.getenv("MQTT_PREFIX")
 mqtt_base = "devices/" + str(mqtt_prefix) + "/"
-mqtt_client = mqtt.Client("HHC-MQTT-Bridge")
+mqtt_client_id = "HHC-MQTT-Bridge-" + str(hashlib.sha256(os.urandom(32)).hexdigest()[:7])
+mqtt_client = mqtt.Client(mqtt_client_id)
 device_driver = None
 
 


### PR DESCRIPTION
Allow multiple instances of HHC MQTT bridge & use requirements.txt on Dockerfile


This PR allows running multiple instances of the HHC MQTT bridge meaning that users can operate multiple network relay controllers concurrently on the same MQTT broker, improving the scalability of the system. This is achieved by generating random MQTT client IDs for each bridge instance.

We also use an actual requirements.txt file to read the project's dependencies instead of hardcoding them in the Dockerfile.