### PR TITLE
Re-register device after HA reboot and get the actual relay statuses from board 

### DIFF
--- a/HHCIODriver.py
+++ b/HHCIODriver.py
@@ -96,6 +96,24 @@ class HHCIODriver(object):
             self._on_socket_disconnect()
             raise ConnectionError("Driver is not connected!")
 
+    def read_outputs(self):
+        if not self.connected:
+            raise ConnectionError("Driver is not connected!")
+
+        try:
+            with self.socket_lock:
+                self.socket.send('read'.encode())
+                data = self.socket.recv(13).decode()
+                bits = data[5:] # length of returned string "relay"
+                # Return bits in reverse order because the relay controller
+                # returns them in a way that the last bit is the first relay
+                return bits[::-1]
+
+        except socket.error as e:
+            logging.critical("Failed to send command \"read\" to the device: {}".format(e))
+            self._on_socket_disconnect()
+            raise ConnectionError("Driver is not connected!")
+
     def read_input(self, input):
         if not self.connected:
             raise ConnectionError("Driver is not connected!")

--- a/main.py
+++ b/main.py
@@ -32,6 +32,14 @@ def on_mqtt_message(client, userdata, message):
                     client.publish(mqtt_base + "outputs/{}/state".format(output_number), "ON")
                 else:
                     client.publish(mqtt_base + "outputs/{}/state".format(output_number), "OFF")
+
+        # Check whether Home Assistant was rebooted needs to 
+        # republish discovery info to re-register the device
+        elif "homeassistant/status" in topic:
+            if os.getenv("HA_COMPATIBLE") is not None:
+                if payload == "online":
+                    publish_ha_discovery_info(client)
+
     except ConnectionError as e:
         #device is not available at this time
         pass
@@ -49,6 +57,10 @@ def on_mqtt_connect(client, userdata, flags, rc):
     client.subscribe(mqtt_base + "outputs/6/command")
     client.subscribe(mqtt_base + "outputs/7/command")
     client.subscribe(mqtt_base + "outputs/8/command")
+
+    if os.getenv("HA_COMPATIBLE") is not None:
+        client.subscribe("homeassistant/status")
+
     logging.info("MQTT is now connected!")
 
 


### PR DESCRIPTION
This PR enables (1)re-registration of the network relay board and (2)fetching of real relay statuses from the relay controller.

1) **Network relay board is re-registered (/discovery messages sent) to Home Assistant on restart**. Without this PR, if the HHCN8I8OP-MQTT instance remains on while only Home Assistant is restarted, the connection between the relay board and HA via this MQTT gateway breaks. This could also be achieved by using retain flag on discovery messages but that approach would complicate the unpairing of these devices from HA.

2) This PR also **fetches relay statuses from the network relay controller every half second intervals** and publishes these states under "outputs" topic that are also defined in HA discovery message. This ensures that our requests have been successfully delivered to the network relay controller and that the state displayed for instance on the Home Assistant dashboard accurately matches the actual states of the relays.